### PR TITLE
get `run_capability_evals.sh` up and running again

### DIFF
--- a/examples/capability_evals/multi_choice/load.py
+++ b/examples/capability_evals/multi_choice/load.py
@@ -58,7 +58,7 @@ def load_dataset_from_config(dataset: str, path_to_dataset: Path | None = None) 
         else:
             raise ValueError(f"Unknown dataset: {dataset}")
 
-    questions = dataset.convert_to_questions()
+    questions = dataset.convert_to_questions(dataset.dataset)
 
     if path_to_dataset is not None:
         path_to_dataset.parent.mkdir(parents=True, exist_ok=True)

--- a/examples/capability_evals/multi_choice/run_multi_choice.py
+++ b/examples/capability_evals/multi_choice/run_multi_choice.py
@@ -122,7 +122,6 @@ async def main(cfg: ExperimentConfig):
             dataset=cfg.dataset,
             path_to_dataset=cfg.path_to_dataset,
         )
-        input_objs = [obj.model_dump() for obj in input_objs]
 
     # shuffle and slice dataset
     random.seed(cfg.seed)


### PR DESCRIPTION
dataset.convert_to_questions takes a dataset as input. This is a bit inelegant since I ended up passing the dataset to itself, so it could be refactored in the future. I didn't refactor this now since the method signature is part of an abstract class, so I didn't want to break anything that relied on that.

Running model_dump on the objects in the dataset causes an error since they are already dicts, so I removed that.

Now doing `./experiments/examples/241223_running_examples/run_capability_evals.sh` works!